### PR TITLE
Carve out introduction, and various other edits

### DIFF
--- a/draft-terminology.md
+++ b/draft-terminology.md
@@ -1,5 +1,5 @@
 ---
-title: Terminology, Power and Offensive Language
+title: Terminology, Power and Inclusive Language
 abbrev: Terminology
 docname: draft-knodel-terminology-01
 date: 2019-03-11
@@ -173,23 +173,27 @@ informative:
 
 --- abstract
 
-This document argues for and describes alternatives that shift specific language conventions used by RFC Authors and RFC Editors to avoid offensive terminology in the technical documentation of the RFC 
-series. Specifically, this document details two sets of terms that are normalised on the technical level but offensive on a societal level. First, arguments are presented for why any offensive terms 
-should be avoided by the IETF/IRTF. Second, problem statements for both sets of terms are presented and alternatives are referenced and proposed. There is a third section on additional considerations and 
-general action points to address the RFC series, past and future. Lastly, a summary of recommendations is presented.
+This document argues for moving away from specific language conventions used by RFC authors and RFC Editors in order to encourage inclusive terminology in the ongoing RFC 
+series. The document also provides examples of inclusive terminology as precise alternatives for these conventions. 
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in {{RFC2119}}.
 
 --- middle
 
+# Introduction
+
+The primary function of the IETF is to publish documents that are "readable, clear, consistent, and reasonably uniform" and one function of the RFC Editor is to "[c]orrect larger content/clarity issues; 
+flag any unclear passages for author review {{RFC7322}}. Given the importance of communication at the IETF, it is worth considering the effects of terminology that has been identified as exclusionary. This document argues that certain obviously exclusionary terms should be avoided and replaced with alternatives.
+
+First, arguments are presented for why exclusionary terms 
+should be avoided by the IETF/IRTF in general. Second, problem statements for two sets of terms are presented and alternatives are referenced and proposed. There is a third section on additional considerations and 
+general action points to address the RFC series, past and future. Lastly, a summary of recommendations is presented.
+
+The sets of terms discussed in this document are "master-slave" and "whitelist-blacklist".
 
 
 # Terminology and power at the IETF
 
-The primary function of the IETF is to publish documents that are "readable, clear, consistent, and reasonably uniform" and one function of the RFC Editor is to "[c]orrect larger content/clarity issues; 
-flag any unclear passages for author review {{RFC7322}}. Given the importance of communication at the IETF, it is worth considering the effects of terminology that has been identified as offensive, 
-racist and sexist. Furthermore, this document argues that certain obviously offensive terms be avoided and replaced with alternatives. These sets of terms are "master-slave" and "white-blacklist" for 
-their racist and race-based meanings.
 
 According to the work of scholar Heather Brodie Graves from 1993, "one goal of the application of rhetorical theory in the technical communication classroom is to assess the appropriateness of particular 
 terms and to evaluate whether these terms will facilitate or hinder the readers’ understanding of the technical material" {{BrodieGravesGraves}}. This implies that in order to effectively communicate the 
@@ -227,7 +231,7 @@ Master-slave is an offensive metaphor that will and should never become fully de
 interviewed for his research. He asks: "If the master-slave metaphor affected these tough-minded engineers who had the gumption to make it through a technical career back in the days when they may have 
 been the only black persons in their classes, what impact might it have on black students who are debating whether or not to enter science and technology careers at all?" {{Eglash}}
 
-Aside from the arguably most important reason outlined above, the term set is becoming less used and therefore increasingly less compatible as more communities move away from its use (eg {{Python}}, 
+Aside from the arguably most important reason outlined above, these terms are becoming less used and therefore increasingly less compatible as more communities move away from its use (eg {{Python}}, 
 {{Drupal}}, and {{Django}}. The usage of 'master' and 'slave' in hardware and software has been halted by the Los Angeles County Office of Affirmative Action, the Django community, the Python community 
 and several other programming languages. This was done because the language is offensive and hurts people in the community {{Django2}}. It is also no longer in use at the IEEE.
 


### PR DESCRIPTION
- Use 'inclusive' and 'exclusive' instead of 'offensive' in abstract and intro as a proposal
- Clean up abstract and create introduction

@mallory @nllz what do you think? I was processing the current conversation around this subject and remembering how this draft had been (mystifyingly) controversial when it was introduced, and it struck me that "inclusivity" might be a better framing than "offensive". Happy to hear disagreement. If you think it's worthwhile, I can follow up with another PR to update the rest of the document accordingly. 