### PR TITLE
Remove inaccurate translation of "robot"

### DIFF
--- a/draft-terminology.md
+++ b/draft-terminology.md
@@ -63,12 +63,6 @@ informative:
       seriesinfo: "Technology and Culture, vol. 48 no. 2, 2007, pp. 360-369."
       target: https://doi.org/10.1353/tech.2007.0066
 
-   Kurfess:
-      title: "Robotics and Automation Handbook"
-      author:
-         - ins: Thomas R. Kurfess
-      date: 2005
-
    BrodieGravesGraves:
       title: "Masters, slaves, and infant mortality: Language challenges for technical editing"
       author:
@@ -212,7 +206,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 According to the work of scholar Heather Brodie Graves from 1993, "one goal of the application of rhetorical theory in the technical communication classroom is to assess the appropriateness of particular terms and to evaluate whether these terms will facilitate or hinder the readers’ understanding of the technical material" {{BrodieGravesGraves}}. This implies that in order to effectively communicate the content of RFCs to all readers, it is important for Authors to consider the kinds of terms or language conventions that may inadvertently get in the way of effective communication. She continues, "complex and subtle configurations of sexist, racist, or ethnocentric language use in technical documents can derail or interfere with readers’ ability and desire to comprehend and follow important information."
 
-Indeed, problems of language are problems of everyday speech. Racist and sexist language is rampant and similarly counter-productive in other sectors, notably social work {{Burgest}}. The terms "master-slave," treated in detail below are present in other realms of technology, notably "automotive clutch and brake systems, clocks, flip-flop circuits, computer drives, and radio transmitters" {{Eglash}}. And the ubiquitous word "robot" is the Czech word for "slave" {{Kurfess}}.
+Indeed, problems of language are problems of everyday speech. Racist and sexist language is rampant and similarly counter-productive in other sectors, notably social work {{Burgest}}. The terms "master-slave," treated in detail below are present in other realms of technology, notably "automotive clutch and brake systems, clocks, flip-flop circuits, computer drives, and radio transmitters" {{Eglash}}.
 
 However as noted in the research by Ron Eglash, this seemingly entrenched technical terminology is relatively recent. It is not too late for these terms to be replaced with alternative metaphors that are more accurate, clearer, less distracting, and that do not offend their readers. Language matters and metaphors matter. Indeed, metaphors can be incredibly useful devices to make more human the complex technical concepts presented in RFCs. Metaphors should not be avoided but rather taken seriously. Renowned linguist George Lakoff argued in 1980 that the ubiquitous use of metaphors in our everyday speech indicates a fundamental instinct to "structure our most basic understandings of experience" {{Lakoff}}. Metaphors structure relationships, and they frame possibilities and impossibilities {{Wyatt}}.
 


### PR DESCRIPTION
In Czech, the word "robot" always refers to a machine.  The only time
I can think of when it is used to describe people, it is used to liken
them to a machine - much like it is common in English to use phrases
such as "robotic voice" or "[they] move like robots".  Such comparisons
(in Czech or English) in no way imply slavery.